### PR TITLE
Refactor local dev environment to use docker for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,37 +36,25 @@ This guide will help you set up the local development environment using SQLite3,
 Prerequisites
 -------------
 
-*   Python 3
-*   pip
+*   docker
 
 Setup Instructions
 ------------------
 
 1.  **Clone the repository**: Copy the repo URL and run `git clone [repo url]` in your terminal, within your desired local directory.
     
-2.  **Install dependencies**: In the project directory, run the following command to install the required packages:
+2.  **Bring up docker**: In the project directory, run the following command:
     
-    `pip install -r requirements.txt`
+    `docker compose -f "docker-compose.dev.yml" up `
     
-3.  **Migrate the database**: Run the following command to apply the necessary migrations:
-    
-    `python3 manage.py migrate`
-    
-4.  **Start the development server**: Run the following command to start the development server on port 8002:
-    
-    ```bash
-    python3 manage.py runserver 8002
-    ```
-    
-5.  **Access the application**: Open your web browser and navigate to the following URL:
+3.  **Access the application**: Open your web browser and navigate to the following URL:
 
-    
     ```bash
     http://127.0.0.1:8002/
     ```
     
 
-Now you should be able to view and interact with the application in your local environment.
+Now you should be able to view and interact with the application in your local environment w/ hot reload.
 
 # Meeting minutes
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,40 @@
+version: '3.4'
+
+services:
+  greysendwebsite:
+    platform: linux/x86_64
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    environment:
+      SECRET_KEY: "django-insecure-+(l4b_3&z9&g=7na=#*1ntg4)w_7&8@*a9@fag_l_1(+z+k=xf"
+      POSTGRES_DB: grey_send_db 
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: asdf1234
+      POSTGRES_HOST: postgres
+      PRODUCTION: false  # set to false for local development
+      DEBUG: true  # enable debug mode for local development
+    ports:
+      - 8002:8002
+    depends_on:
+      - postgres
+    volumes:
+      - .:/app
+    command: >
+      bash -c "cd /app/greysend_project && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:8002"
+
+  postgres:
+    platform: linux/x86_64
+    image: postgres:14.7
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: asdf1234
+      POSTGRES_USER: admin
+      POSTGRES_DB: grey_send_db
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres-data:/var/lib/postgresql/data/
+
+volumes:
+  postgres-data:

--- a/greysend_project/chat/templates/landing_page.html
+++ b/greysend_project/chat/templates/landing_page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Welcome to my site</title>
+</head>
+<body>
+    <h1>Welcome to my Chat App</h1>
+    <p>Thank you for visiting my site. Please take a moment to explore and see what we have to offer.</p>
+</body>
+</html>

--- a/greysend_project/chat/views.py
+++ b/greysend_project/chat/views.py
@@ -1,3 +1,10 @@
 from django.shortcuts import render
+from django.http import HttpResponse
 
 # Create your views here.
+def test_view(request):
+    return HttpResponse("This is a test endpoint!")
+
+
+def landing_page(request):
+    return render(request, 'landing_page.html')

--- a/greysend_project/greysend_project/settings.py
+++ b/greysend_project/greysend_project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "chat"
 ]
 
 MIDDLEWARE = [

--- a/greysend_project/greysend_project/urls.py
+++ b/greysend_project/greysend_project/urls.py
@@ -15,7 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from chat.views import test_view
+from chat.views import landing_page
 
 urlpatterns = [
+    path('', landing_page, name='landing_page'),
     path("admin/", admin.site.urls),
+    path('test/', test_view, name='test'),
+
 ]


### PR DESCRIPTION
- Create docker-compose.dev.yml to simplify local dev environment with hot-reload. It runs all migrations and starts development server. 

You can run and test it with: 

```
docker compose -f "docker-compose.dev.yml" up 
```

- Added http://localhost:8002/test/  endpoint 
- Modified / to go to custom index page