### PR TITLE
added generic IP to ALLOWED_HOSTS

### DIFF
--- a/greysend_project/greysend_project/settings.py
+++ b/greysend_project/greysend_project/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'secret')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['0.0.0.0']
 
 # Application definition
 


### PR DESCRIPTION
Host address "0.0.0.0" needed to be added to "ALLOWED_HOSTS" in settings.py. After doing this, we can access "0.0.0.0:8000" now.
When "DEBUG" is set to true in settings.py, "127.0.0.1" and ":::1" and ".localhost" are added to "ALLOWED_HOSTS" by default, but not "0.0.0.0". 


Also - I found this article that explained why we must put 0.0.0.0 in the Dockerfile instead of 127.0.0.1.
https://stackoverflow.com/questions/59179831/docker-app-server-ip-address-127-0-0-1-difference-of-0-0-0-0-ip