### PR TITLE
Bump sqlparse==0.4.3 to 0.4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 asgiref==3.6.0
 Django==4.2
 psycopg2-binary==2.9.6
-sqlparse==0.4.3
+sqlparse==0.4.4


### PR DESCRIPTION
The following vulnerabilities are fixed by pinning transitive dependencies:
- https://snyk.io/vuln/SNYK-PYTHON-SQLPARSE-5426157