### PR TITLE
fix bug on Accounts.user page

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       POSTGRES_HOST: postgres
       PRODUCTION: false  # set to false for local development
       DEBUG: true  # enable debug mode for local development
+      DATABASE: postgresql # use postgresql within the docker container
     ports:
       - 8002:8002
     depends_on:

--- a/greysend_project/greysend_project/settings.py
+++ b/greysend_project/greysend_project/settings.py
@@ -84,7 +84,7 @@ DATABASES = {
 }
 
 # Use postgres DB when in proudction environment
-if os.environ.get('PRODUCTION') == 'true':
+if os.environ.get('DATABASE') == 'postgresql':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
- With this change, we have now transitioned to using PostgreSQL within Docker.
- Previously, we were using the SQLite database by default.

You will have to docker exec into the docker container and create a superuser.

1. docker ps
2. docker exec -it <container_id> /bin/bash
3. python manage.py createsuperuser
4. After folllowing above steps navigate to http://0.0.0.0:8002/admin/ and login with the newly created user
5. You can now see http://0.0.0.0:8002/accounts/members reflecting the expected users. 